### PR TITLE
Fix for exception caused by float specials and support for 2 more operators

### DIFF
--- a/src/mongodb.erl
+++ b/src/mongodb.erl
@@ -1359,8 +1359,13 @@ decode_value(16, <<Integer:32/little-signed, Rest/binary>>) ->
 	{Integer, Rest};
 decode_value(18, <<Integer:64/little-signed, Rest/binary>>) ->
 	{Integer, Rest};
-decode_value(1, <<Double:64/little-signed-float, Rest/binary>>) ->
-	{Double, Rest};
+decode_value(1, <<DoubleBin:8/binary, Rest/binary>>) ->
+  try
+    <<Double:64/little-signed-float>> = DoubleBin,
+    {Double, Rest}
+  catch error:{badmatch, _Bin} ->
+    {0, Rest}
+  end;
 decode_value(2, <<Size:32/little-signed, Rest/binary>>) ->
 	StringSize = Size-1,
 	case Rest of


### PR DESCRIPTION
- Added `$each` and `$slice` modifiers for `$push` operator
- Added decoding for `$near` operator (for simple 2d queries).
- For complex 2d queries there's a `$geoNear` command which can be invoked by `mongoapi:runCmd(...)`
  This command returns some statistics. And I ran into a problem when one of the fields in those stats may be NaN. And Erlang does not support float special values like NaN, +/-Inf, +/-0. Trying to match it causes exception. I added a simplest workaround and you may want to match those values directly by specifying them, although I don't know what to return in those cases - right now I left it to int 0 for any special value.
