### PR TITLE
Fix crash when ets:info(Pool,size)=1

### DIFF
--- a/src/mongodb.erl
+++ b/src/mongodb.erl
@@ -225,7 +225,7 @@ trysend(Pool,Query,Type) when is_atom(Pool) ->
 		0 ->
 			not_connected;
 		_ ->
-			Pos = rand:uniform(Sz-1),
+			Pos = rand:uniform(Sz)-1,
 			case (catch ets:slot(Pool,Pos)) of
 				[{Pid}] ->
 					trysend(Pid,Query,Type);


### PR DESCRIPTION
rand:uniform(Sz) requires Sz >= 1, so when Sz=1, then rand:uniform(Sz-1) causes a crash